### PR TITLE
Makes designer lines have actual links inside

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -171,11 +171,11 @@ function Content({ designers, handleOpenFilter, className, onClick }) {
           {designers != null ? (
             <tbody>
               {designers.map((d, i) => (
-                <tr key={`${d.name}-${i}`} onClick={() => window.open(d.link)}>
-                  <td>{d.name}</td>
-                  <td className="thsize-aux dn">{d.location}</td>
-                  <td className="thsize-aux">{d.expertise}</td>
-                  <td className="thsize-link">→</td>
+                <tr key={`${d.name}-${i}`}>
+                  <td><a href={d.link}>{d.name}</a></td>
+                  <td className="thsize-aux dn"><a href={d.link}>{d.location}</a></td>
+                  <td className="thsize-aux"><a href={d.link}>{d.expertise}</a></td>
+                  <td className="thsize-link"><a href={d.link}>→</a></td>
                 </tr>
               ))}
             </tbody>
@@ -208,6 +208,19 @@ function Content({ designers, handleOpenFilter, className, onClick }) {
           .thsize-aux {
             width: 30%;
           }
+        }
+
+        tbody a {
+          width: 100%;
+          padding-bottom: 0.6em;
+          padding-top: 0.6em;
+          color: inherit;
+          display: inline-block;
+        }
+
+        table tbody td {
+          padding-top: 0;
+          padding-bottom: 0;
         }
       `}</style>
 


### PR DESCRIPTION
Hi!

**Why**
I really wanted to scroll-click on lots of links and I couldn't D:
Other than that having links that don't use anchor tags is not good for SEO, since search engine crawlers won't understand this content.

**How**
My implementation was pretty quick and dirty: I've added more CSS inline rules, overriding your `Modernism` styles and duplicating links for each table row.
It however works well across browsers, and doesn't produce semantically invalid HTML (which would be the case if the whole row was a link).
The ideal solution would need to refactor the layout to not use tables, but probably not cost-effective.

**What**
Every table cell is now wrapped by an anchor tag.

![image](https://user-images.githubusercontent.com/467471/89458513-81dde000-d73d-11ea-8b75-1e99efea826d.png)
